### PR TITLE
add test evaluate_fitness func

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,21 @@
+import pytest
+import numpy as np
+from core.population import evaluate_fitness
+from benchmark.sphere import sphere
+
+
+# Creates a dummy solution vector
+@pytest.mark.parametrize("solution", [
+    [1, 0.0, 3],
+    [1.0, 2.0, 3.0],
+    [0.0, 0.0, 0.0],
+    [-1.0, 2.5, -3.7],
+    np.array([4.0, 5.0, 6.0]),
+])
+def test_evaluate_fitness(solution):
+    # Passes it to evaluate_fitness using the sphere function
+    result = evaluate_fitness(solution, sphere)
+
+    assert isinstance(result, float)
+    assert not isinstance(result, list)
+    assert not isinstance(result, np.ndarray)


### PR DESCRIPTION
Created a dummy solution vector.
Passed it to evaluate_fitness using the sphere function.
Checked that the result is a float and not a list or array.
Used pytest.
I did not write numbers of the int type in the test values, perhaps this was incorrect, but it seemed to me that this is how it should be. Write if you need to consider test cases of the type - [1, 0, 3], [0, 0, 0] and so on, I will correct.